### PR TITLE
Make GET /resource public

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -19,7 +19,7 @@ jobs:
         python-version: ["3.12"]
     services:
       mongodb:
-        image: mongo:4.0
+        image: mongo:4.2
         ports:
           - 27017:27017
       redis:

--- a/girder_wholetale/__init__.py
+++ b/girder_wholetale/__init__.py
@@ -510,7 +510,7 @@ def signIn(self, redirect):
         raise cherrypy.HTTPRedirect(redirect)
 
 
-@access.user
+@access.public
 @autoDescribeRoute(
     Description("Get a set of items and folders.")
     .jsonParam(

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     name="girder-wholetale",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    version="2.0.9",
+    version="2.0.10",
     description="Girder plugin implementing Whole Tale core functionality.",
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
This pull request makes a minor update to the `girder-wholetale` package, including a version bump and a change to the access level of a route.

Version update:

* Bumped the package version from `2.0.9` to `2.0.10` in `setup.py` to reflect recent changes.

Access control change:

* Changed the access decorator for the route `GET /resource` from `@access.user` to `@access.public` in `girder_wholetale/__init__.py`, making the endpoint accessible without authentication.